### PR TITLE
Upgrade jsonrpc framework to use closeable state

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -3,7 +3,7 @@ module github.com/threefoldtech/web3_proxy/server
 go 1.20
 
 require (
-	github.com/LeeSmet/go-jsonrpc v0.0.0-20230421090739-7ea9777273cb
+	github.com/LeeSmet/go-jsonrpc v0.0.0-20230525114004-084cdb6d9fe8
 	github.com/btcsuite/btcd v0.23.4
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2

--- a/server/go.sum
+++ b/server/go.sum
@@ -13,6 +13,8 @@ github.com/ChainSafe/go-schnorrkel v1.0.0/go.mod h1:dpzHYVxLZcp8pjlV+O+UR8K0Hp/z
 github.com/DataDog/zstd v1.5.5 h1:oWf5W7GtOLgp6bciQYDmhHHjdhYkALu6S/5Ni9ZgSvQ=
 github.com/LeeSmet/go-jsonrpc v0.0.0-20230421090739-7ea9777273cb h1:/2hRGzqujnvMJQ1x3pB8ZpwO6/pNsR3BjbB+Q4o9054=
 github.com/LeeSmet/go-jsonrpc v0.0.0-20230421090739-7ea9777273cb/go.mod h1:iLgTxMgzjJVm4Op6Ws8qXUgjPojQIrcXi3X4oIkllkU=
+github.com/LeeSmet/go-jsonrpc v0.0.0-20230525114004-084cdb6d9fe8 h1:J9EEAsHuO3ASS1cLEmqX+m+CcTJypBz9z3UeyZFpEO0=
+github.com/LeeSmet/go-jsonrpc v0.0.0-20230525114004-084cdb6d9fe8/go.mod h1:iLgTxMgzjJVm4Op6Ws8qXUgjPojQIrcXi3X4oIkllkU=
 github.com/SaveTheRbtz/generic-sync-map-go v0.0.0-20220414055132-a37292614db8 h1:Xa6tp8DPDhdV+k23uiTC/GrAYOe4IdyJVKtob4KW3GA=
 github.com/SaveTheRbtz/generic-sync-map-go v0.0.0-20220414055132-a37292614db8/go.mod h1:ihkm1viTbO/LOsgdGoFPBSvzqvx7ibvkMzYp3CgtHik=
 github.com/VictoriaMetrics/fastcache v1.12.1 h1:i0mICQuojGDL3KblA7wUNlY5lOK6a4bwt3uRKnkZU40=

--- a/server/pkg/atomic_swap/client.go
+++ b/server/pkg/atomic_swap/client.go
@@ -66,6 +66,9 @@ func State(conState jsonrpc.State) *AtomicSwapState {
 	return ns
 }
 
+// Close implements jsonrpc.Closer
+func (s *AtomicSwapState) Close() {}
+
 func (c *Client) Load(ctx context.Context, conState jsonrpc.State) error {
 	nostrState := nostrpkg.State(conState)
 	if nostrState.Client == nil {

--- a/server/pkg/btc/client.go
+++ b/server/pkg/btc/client.go
@@ -115,6 +115,9 @@ func State(conState jsonrpc.State) *btcState {
 	return ns
 }
 
+// Close implements jsonrpc.Closer
+func (s *btcState) Close() {}
+
 func NewClient() *Client {
 	return &Client{}
 }

--- a/server/pkg/eth/client.go
+++ b/server/pkg/eth/client.go
@@ -57,6 +57,9 @@ func State(conState jsonrpc.State) *EthState {
 	return ns
 }
 
+// Close implements jsonrpc.Closer
+func (s *EthState) Close() {}
+
 // Load a client, connecting to the rpc endpoint at the given URL and loading a keypair from the given secret
 func (c *Client) Load(ctx context.Context, conState jsonrpc.State, args Load) error {
 	cl, err := goethclient.NewClient(args.Url, args.Secret)

--- a/server/pkg/ipfs/client.go
+++ b/server/pkg/ipfs/client.go
@@ -46,6 +46,9 @@ func State(conState jsonrpc.State) *ipfsState {
 	return ns
 }
 
+// Close implements jsonrpc.Closer
+func (s *ipfsState) Close() {}
+
 func NewClient(peer *ipfslite.Peer) *Client {
 	return &Client{peer: peer}
 }

--- a/server/pkg/nostr/client.go
+++ b/server/pkg/nostr/client.go
@@ -42,6 +42,9 @@ func State(conState jsonrpc.State) *NostrState {
 	return ns
 }
 
+// Close implements jsonrpc.Closer
+func (s *NostrState) Close() {}
+
 // NewClient creates a new client
 func NewClient() *Client {
 	return &Client{

--- a/server/pkg/stellar/client.go
+++ b/server/pkg/stellar/client.go
@@ -52,6 +52,9 @@ const (
 	StellarID = "stellar"
 )
 
+// Close implements jsonrpc.Closer
+func (s *StellarState) Close() {}
+
 // Error implements the error interface
 func (e ErrUnknownNetwork) Error() string {
 	return "only 'public' and 'testnet' networks are supported"

--- a/server/pkg/tfchain/client.go
+++ b/server/pkg/tfchain/client.go
@@ -145,6 +145,9 @@ func State(conState jsonrpc.State) *TfchainState {
 	return ns
 }
 
+// Close implements jsonrpc.Closer
+func (s *TfchainState) Close() {}
+
 // NewClient creates a new Client ready for use
 func NewClient() *Client {
 	return &Client{

--- a/server/pkg/tfgrid/client.go
+++ b/server/pkg/tfgrid/client.go
@@ -65,6 +65,9 @@ func State(conState jsonrpc.State) *tfgridState {
 	return ns
 }
 
+// Close implements jsonrpc.Closer
+func (s *tfgridState) Close() {}
+
 // Load an identity for the tfgrid with the given network
 func (c *Client) Load(ctx context.Context, conState jsonrpc.State, mnemonic string, network string) error {
 	state := State(conState)


### PR DESCRIPTION
All state now requires a `Close` method which is invoked when the state is dropped. For regular state, this function can be left blank