### PR TITLE
Set stellar v client default network to public

### DIFF
--- a/lib/stellar/stellar.v
+++ b/lib/stellar/stellar.v
@@ -8,31 +8,31 @@ const (
 
 [params]
 pub struct Load {
-	network string
-	secret string
+	network string = 'public'
+	secret  string
 }
 
 [params]
 pub struct Transfer {
-	amount string
+	amount      string
 	destination string
-	memo string
+	memo        string
 }
 
 [params]
 pub struct BridgeTransfer {
-	amount string
+	amount      string
 	destination string
 }
 
 [params]
 pub struct TfchainBridgeTransfer {
-	amount string
+	amount  string
 	twin_id u32
 }
 
-
-[noinit; openrpc: exclude]
+[openrpc: exclude]
+[noinit]
 pub struct StellarClient {
 mut:
 	client &RpcWsClient
@@ -47,22 +47,24 @@ pub fn new(mut client RpcWsClient) StellarClient {
 
 // Load a client, connecting to the rpc endpoint at the given network and loading a keypair from the given secret.
 pub fn (mut s StellarClient) load(args Load) ! {
-	_ := s.client.send_json_rpc[[]Load, string]('stellar.Load', [args], default_timeout)!
+	_ := s.client.send_json_rpc[[]Load, string]('stellar.Load', [args], stellar.default_timeout)!
 }
 
 // Transfer an amount of TFT from the loaded account to the destination.
 pub fn (mut s StellarClient) transfer(args Transfer) ! {
-	_ := s.client.send_json_rpc[[]Transfer, string]('stellar.Transfer', [args], default_timeout)!
+	_ := s.client.send_json_rpc[[]Transfer, string]('stellar.Transfer', [args], stellar.default_timeout)!
 }
 
 // Balance of an account for TFT on stellar.
-pub fn (mut s StellarClient) balance(address string) ! i64 {
-	return s.client.send_json_rpc[[]string, i64]('stellar.Balance', [address], default_timeout)!
+pub fn (mut s StellarClient) balance(address string) !i64 {
+	return s.client.send_json_rpc[[]string, i64]('stellar.Balance', [address], stellar.default_timeout)!
 }
 
 // bridge_to_eth bridge to eth from stellar
 pub fn (mut s StellarClient) bridge_to_eth(args BridgeTransfer) ! {
-	_ := s.client.send_json_rpc[[]BridgeTransfer, string]('stellar.BridgeToEth', [args], default_timeout)!
+	_ := s.client.send_json_rpc[[]BridgeTransfer, string]('stellar.BridgeToEth', [
+		args,
+	], stellar.default_timeout)!
 }
 
 // Reinstate later
@@ -74,5 +76,6 @@ pub fn (mut s StellarClient) bridge_to_eth(args BridgeTransfer) ! {
 
 // bridge_to_tfchain bridge to tfchain from stellar
 pub fn (mut s StellarClient) bridge_to_tfchain(args TfchainBridgeTransfer) ! {
- 	_ := s.client.send_json_rpc[[]TfchainBridgeTransfer, string]('stellar.BridgeToTfchain', [args], default_timeout)!
+	_ := s.client.send_json_rpc[[]TfchainBridgeTransfer, string]('stellar.BridgeToTfchain',
+		[args], stellar.default_timeout)!
 }


### PR DESCRIPTION
This simplifies it a bit for users of the v client as the network is no required parameter now when creating a stellar client.