### PR TITLE
146 openrpc document is not correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ Follow the steps [here](server/) to add the client to the json rpc 2.0 server an
 
 To generate the documentation for the project, run `v run doc.vsh`. This builds: 
 - MDBook Documentation in html format from content in manual folder in `docs`. 
-- OpenRPC Documents for the JSON-RPC API's at `docs/openrpc`.
+- OpenRPC Documents for the JSON-RPC API's at `docs/openrpc` from V clients in `lib`.
 - OpenRPC Playground for the JSON-RPC API's at `docs/playground`.
+
+Find out more about how comments in code are used to generate OpenRPC Documents for domains, and how to annotate your code accordingly [here](https://github.com/freeflowuniverse/crystallib/tree/development/openrpc)
 
 To locally generate specific documents and not all of the aforementioned artifacts, comment out the [lines](https://github.com/threefoldtech/web3_proxy/blob/596331a5051d15502681d200fa408ee0983debc0/doc.vsh#LL88-L91) in the doc.vsh script accordingly.
 

--- a/doc.vsh
+++ b/doc.vsh
@@ -38,7 +38,7 @@ fn build_openrpc_docs() ! {
 		client_name := client.path.all_after_last('/')
 		sh('mkdir docs/openrpc/$client_name')
 		doc_title := "$client_name JSON-RPC API"
-		sh('$cli docgen -t "$doc_title" -p -o docs/openrpc/$client_name $client.path')
+		sh('$cli docgen -exclude_dirs threelang -t "$doc_title" -p -o docs/openrpc/$client_name $client.path')
 	}
 }
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -5,18 +5,21 @@ This section of the repository contains the implementation of a V client library
 For example:
 
 ```
-[noinit]
+[noinit; openrpc: exclude]
 pub struct TfChainClient {
 mut:
 	client &RpcWsClient
 }
 
+[openrpc: exclude]
 pub fn new(mut client RpcWsClient) TfChainClient {
 	return TfChainClient{
 		client: &client
 	}
 }
 ```
+
+Note that in the above example, the `openrpc: exclude` attribute is used to tell the OpenRPC Document generator to exclude the client struct and factory function from the OpenRPC Document.
 
 For each of the remote procedure calls on the server side (in go) there should be a V function. You can find two examples below. The first example does not return anything, the second does. Each function sends a json rpc message using the RpcWsClient. That function has two generics (the values between square brackets). The first generic defines the type of parameters that you want to send (this will be serialized in the params field of the json 2.0 rpc request). The second defines the type of object that you expect to receive (the result field of a json 2.0 rpc response).
 

--- a/lib/metrics/metrics.v
+++ b/lib/metrics/metrics.v
@@ -31,6 +31,7 @@ const (
 	}
 )
 
+[openrpc: exclude]
 pub fn get_metrics_url(args MetricsURLArgs, mut explorer_cl explorer.ExplorerClient, mut logger log.Logger) !string{
 
 	env := envs[args.network] or {panic('env not found')}

--- a/lib/sftpgo/sftpgo.v
+++ b/lib/sftpgo/sftpgo.v
@@ -3,14 +3,14 @@ import json
 import net.http
 import encoding.base64
 
-[noinit]
+[noinit; openrpc: exclude]
 pub struct SFTPGoClient {
 pub mut:
 	address string
 	header http.Header
 }
 
-[params]
+[params; openrpc: exlude]
 pub struct SFTPGOClientArgs {
 pub:
 	address    string = 'http://localhost:8080/api/v2'
@@ -29,6 +29,7 @@ pub:
 	admin string
 }
 
+[openrpc: exclude]
 pub fn new(args SFTPGOClientArgs) !SFTPGoClient {
 	header := http.new_custom_header_from_map({'X-SFTPGO-API-KEY': args.key})!
 	return SFTPGoClient{


### PR DESCRIPTION
Fixes #146 
One of the problems that caused the issue was: "Metrics client library RPC call is not declared in the standard other clients follow, where the client is the receiver of the function. This is presumably because methods can't be declared outside modules." 

As part of the solution commit 165f6c8 ignores the metrics module in OpenRPC Document generation. @ashraffouda is that acceptable, or is the metrics method required to be included in the document. If so can we consider merging it into the explorer module to have the client passed to the [function](https://github.com/threefoldtech/web3_proxy/blob/da24e7851bf07a77ebd30c1426004654b31d662a/lib/metrics/metrics.v#L34) as a receiver and not as a parameter.